### PR TITLE
Support symbols or strings as milestone keys

### DIFF
--- a/addon/-private/milestone-handle.ts
+++ b/addon/-private/milestone-handle.ts
@@ -7,6 +7,7 @@ import MilestoneCoordinator from 'ember-milestones/-private/milestone-coordinato
 import {
   CancelableDeferred,
   MilestoneHandle as IMilestoneHandle,
+  MilestoneKey,
   ResolutionOptions,
 } from 'ember-milestones';
 
@@ -17,7 +18,7 @@ export default class MilestoneHandle implements IMilestoneHandle {
   private resolution: Resolution | null = null;
 
   constructor(
-    public name: string,
+    public name: MilestoneKey,
     private _coordinator: MilestoneCoordinator,
     private _action: () => any,
     private _deferred: CancelableDeferred,
@@ -49,7 +50,10 @@ export default class MilestoneHandle implements IMilestoneHandle {
   }
 
   private _complete(resolution: Resolution, options: ResolutionOptions = {}, finalizer: () => void): Promise<void> {
-    assert(`Multiple resolutions for milestone ${this.name}`, !this.resolution || this.resolution === resolution);
+    assert(
+      `Multiple resolutions for milestone '${this.name.toString()}'`,
+      !this.resolution || this.resolution === resolution,
+    );
 
     if (!this.resolution) {
       this.resolution = resolution;

--- a/addon/-private/milestone-target.ts
+++ b/addon/-private/milestone-target.ts
@@ -1,6 +1,7 @@
 import logger from 'debug';
 import {
   MilestoneHandle,
+  MilestoneKey,
   MilestoneTarget as IMilestoneTarget,
   ResolutionOptions,
 } from 'ember-milestones';
@@ -13,7 +14,7 @@ export default class MilestoneTarget implements IMilestoneTarget {
   private _coordinatorDeferred: RSVP.Deferred<MilestoneHandle> = defer();
 
   constructor(
-    public name: string,
+    public name: MilestoneKey,
   ) {}
 
   public then<TResult1 = MilestoneHandle, TResult2 = never>(

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -11,7 +11,7 @@ const debugInactive = logger('ember-milestones:inactive');
  * Inactive milestones will pass through to their given callbacks as though the
  * milestone wrapper weren't present at all...
  */
-export function activateMilestones(milestones: string[]): MilestoneCoordinator {
+export function activateMilestones(milestones: MilestoneKey[]): MilestoneCoordinator {
   return new CoordinatorImpl(milestones);
 }
 
@@ -38,10 +38,10 @@ export function deactivateAllMilestones(): void {
  *
  *     await advanceTo('my-component#poller').andContinue();
  */
-export function advanceTo(name: string): MilestoneTarget {
+export function advanceTo(name: MilestoneKey): MilestoneTarget {
   let coordinator = CoordinatorImpl.forMilestone(name);
   if (!coordinator) {
-    throw new Error(`Milestone ${name} isn't currently active.`);
+    throw new Error(`Milestone ${name.toString()} isn't currently active.`);
   } else {
     return coordinator.advanceTo(name);
   }
@@ -55,9 +55,9 @@ export function advanceTo(name: string): MilestoneTarget {
  * When not activated, code wrapped in a milestone is immediately invoked as though
  * the wrapper weren't there at all.
  */
-export function milestone<T extends PromiseLike<any>>(name: string, callback: () => T): T;
-export function milestone(name: string): PromiseLike<void>;
-export function milestone(name: string, callback?: () => any): PromiseLike<any> {
+export function milestone<T extends PromiseLike<any>>(name: MilestoneKey, callback: () => T): T;
+export function milestone(name: MilestoneKey): PromiseLike<void>;
+export function milestone(name: MilestoneKey, callback?: () => any): PromiseLike<any> {
   let coordinator = CoordinatorImpl.forMilestone(name);
   let action = callback || (() => Promise.resolve());
   if (coordinator) {
@@ -87,7 +87,7 @@ export function milestone(name: string, callback?: () => any): PromiseLike<any> 
  * In most cases, using the importable `advanceTo` should mean you won't need to
  * use the `as` parameter.
  */
-export function setupMilestones(hooks: TestHooks, names: string[], options: MilestoneTestOptions = {}) {
+export function setupMilestones(hooks: TestHooks, names: MilestoneKey[], options: MilestoneTestOptions = {}) {
   let milestones: MilestoneCoordinator;
 
   hooks.beforeEach(function(this: any) {
@@ -104,6 +104,11 @@ export function setupMilestones(hooks: TestHooks, names: string[], options: Mile
 }
 
 /**
+ * A valid key for a milestone, either a string or a symbol.
+ */
+export type MilestoneKey = string | symbol;
+
+/**
  * A `MilestoneCoordinator` is the result of an `activateMilestones` call,
  * which provides the ability to interact with the milestones you've activated
  * and subsequently deactivate them.
@@ -117,7 +122,7 @@ export interface MilestoneCoordinator {
    * Advance until the given milestone is reached, continuing past any others
    * that are active for this coordinator in the meantime.
    */
-  advanceTo(name: string): MilestoneTarget;
+  advanceTo(name: MilestoneKey): MilestoneTarget;
 
   /**
    * Deactivate all milestones associated with this coordinator.

--- a/tests/integration/milestones-test.ts
+++ b/tests/integration/milestones-test.ts
@@ -3,247 +3,260 @@ import { advanceTo, deactivateAllMilestones, milestone, setupMilestones } from '
 import { module, test } from 'qunit';
 import { resolve } from 'rsvp';
 
-module('Integration | milestones', function(hooks) {
-  let program: () => Promise<{ first: number, second: number }>;
-  let location: string;
+module('Integration | milestones', function() {
+  let scenarios = [
+    { name: 'with string keys', milestones: ['one', 'two'] },
+    { name: 'with symbol keys', milestones: [Symbol('one'), Symbol('two')] },
+    { name: 'with mixed keys', milestones: ['one', Symbol('two')] },
+  ];
 
-  hooks.beforeEach(function() {
-    location = 'unstarted';
-    program = async () => {
-      location = 'before';
-      let first = await milestone('one', async () => { location = 'one-started'; return 1; });
-      location = 'one-completed';
-      let second = await milestone('two', async () => { location = 'two-started'; return 2; });
-      location = 'two-completed';
-      return { first, second };
-    };
-  });
+  for (let { name, milestones: [keyOne, keyTwo] } of scenarios) {
+    module(name, function(hooks) {
+      let program: () => Promise<{ first: number, second: number }>;
+      let location: string;
 
-  module('with no milestones active', function() {
-    test('milestones with callbacks are inert', async function(assert) {
-      let { first, second } = await program();
-      assert.equal(location, 'two-completed');
-      assert.equal(first, 1);
-      assert.equal(second, 2);
-    });
+      hooks.beforeEach(function() {
+        location = 'unstarted';
+        program = async () => {
+          location = 'before';
+          let first = await milestone(keyOne, async () => { location = 'one-started'; return 1; });
+          location = 'one-completed';
+          let second = await milestone(keyTwo, async () => { location = 'two-started'; return 2; });
+          location = 'two-completed';
+          return { first, second };
+        };
+      });
 
-    test('milestones without callbacks are inert', async function(assert) {
-      let program = async () => {
-        let first = await milestone('one');
-        let second = await milestone('two');
-        return { first, second };
-      };
+      module('with no milestones active', function() {
+        test('milestones with callbacks are inert', async function(assert) {
+          let { first, second } = await program();
+          assert.equal(location, 'two-completed');
+          assert.equal(first, 1);
+          assert.equal(second, 2);
+        });
 
-      assert.deepEqual(await program(), {
-        first: undefined,
-        second: undefined,
+        test('milestones without callbacks are inert', async function(assert) {
+          let program = async () => {
+            let first = await milestone(keyOne);
+            let second = await milestone(keyTwo);
+            return { first, second };
+          };
+
+          assert.deepEqual(await program(), {
+            first: undefined,
+            second: undefined,
+          });
+        });
+      });
+
+      module('with milestones active', function(hooks) {
+        setupMilestones(hooks, [keyOne, keyTwo]);
+
+        test('skipping a milestone', async function(assert) {
+          let programPromise = program();
+
+          let two = await advanceTo(keyTwo);
+          assert.equal(location, 'one-completed');
+
+          two.continue();
+          assert.equal(location, 'two-started');
+
+          let { first, second } = await programPromise;
+          assert.equal(location, 'two-completed');
+          assert.equal(first, 1);
+          assert.equal(second, 2);
+        });
+
+        test('advancing to an already-waiting milestone', async function(assert) {
+          let programPromise = program();
+          assert.equal(location, 'before');
+
+          await advanceTo(keyOne);
+          assert.equal(location, 'before');
+
+          await advanceTo(keyTwo).andContinue();
+
+          let { first, second } = await programPromise;
+          assert.equal(first, 1);
+          assert.equal(second, 2);
+        });
+
+        test('advancing to a not-yet-waiting milestone', async function(assert) {
+          let advancePromise = advanceTo(keyTwo);
+
+          let programPromise = program();
+          assert.equal(location, 'one-started');
+
+          await advancePromise;
+          assert.equal(location, 'one-completed');
+
+          deactivateAllMilestones();
+          await programPromise;
+        });
+
+        test('advancing while paused at a previous milestone', async function(assert) {
+          let programPromise = program();
+
+          await advanceTo(keyOne);
+          assert.equal(location, 'before');
+
+          let two = await advanceTo(keyTwo);
+          assert.equal(location, 'one-completed');
+
+          two.continue();
+
+          assert.deepEqual(await programPromise, { first: 1, second: 2 });
+        });
+
+        test('continuing occurs in a runloop', async function(assert) {
+          let program = async () => {
+            let run = false;
+            await milestone(keyOne, async () => schedule('actions', () => run = true));
+            return run;
+          };
+
+          let programPromise = program();
+          let handle = await advanceTo(keyOne);
+
+          handle.continue();
+          assert.deepEqual(await programPromise, true);
+        });
+
+        test('stubbing a return value', async function(assert) {
+          let programPromise = program();
+
+          await advanceTo(keyOne).andReturn(111);
+          await advanceTo(keyTwo).andReturn(222);
+          assert.equal(location, 'two-completed');
+
+          let { first, second } = await programPromise;
+          assert.equal(first, 111);
+          assert.equal(second, 222);
+        });
+
+        test('throwing an exception', async function(assert) {
+          let boom = new Error('boom!');
+          let program = async () => {
+            try {
+              await milestone(keyOne, async () => 'bad');
+            } catch (error) {
+              return error;
+            }
+          };
+
+          advanceTo(keyOne).andThrow(boom);
+          assert.equal(await program(), boom);
+        });
+
+        test('with no callback', async function(assert) {
+          let program = async () => {
+            let first = await milestone(keyOne);
+            let second = await milestone(keyTwo);
+            return { first, second };
+          };
+
+          let programPromise = program();
+          await advanceTo(keyOne).andContinue();
+          await advanceTo(keyTwo).andContinue();
+          assert.deepEqual(await programPromise, { first: undefined, second: undefined });
+        });
+
+        test('stepping through each location', async function(assert) {
+          let programPromise = program();
+
+          let one = await advanceTo(keyOne);
+          assert.equal(location, 'before');
+
+          one.continue();
+          assert.equal(location, 'one-started');
+
+          let two = await advanceTo(keyTwo);
+          assert.equal(location, 'one-completed');
+
+          two.continue();
+          assert.equal(location, 'two-started');
+
+          await programPromise;
+          assert.equal(location, 'two-completed');
+        });
+
+        test('nested milestones', async function(assert) {
+          let program = async () => {
+            location = 'before-out';
+            let result = await milestone(keyOne, async () => {
+              location = 'before-in';
+              let inner = await milestone(keyTwo, async () => {
+                location = 'in';
+                return 'ok';
+              });
+              location = 'after-in';
+              return inner;
+            });
+            location = 'after-out';
+            return result;
+          };
+
+          let programPromise = program();
+
+          let one = await advanceTo(keyOne);
+          assert.equal(location, 'before-out');
+
+          let two = await advanceTo(keyTwo);
+          assert.equal(location, 'before-in');
+
+          let twoCompletion = two.continue({ immediate: true });
+          assert.equal(location, 'in');
+
+          await twoCompletion;
+          assert.equal(location, 'after-in');
+
+          await one.continue();
+          assert.equal(location, 'after-out');
+
+          assert.equal(await programPromise, 'ok');
+        });
+
+        test('immediate vs deferred continuation', async function(assert) {
+          let program = async () => {
+            location = 'before';
+
+            let result = await milestone(keyOne, async () => 'ok');
+
+            location = 'between';
+
+            await resolve();
+
+            location = 'after';
+
+            return result;
+          };
+
+          let programPromise = program();
+          assert.equal(location, 'before');
+          await advanceTo(keyOne).andContinue({ immediate: true });
+          assert.equal(location, 'between');
+          assert.equal(await programPromise, 'ok');
+
+          programPromise = program();
+          assert.equal(location, 'before');
+          await advanceTo(keyOne).andContinue();
+          assert.equal(location, 'after');
+          assert.equal(await programPromise, 'ok');
+        });
       });
     });
-  });
-
-  module('with milestones active', function(hooks) {
-    setupMilestones(hooks, ['one', 'two']);
-
-    test('skipping a milestone', async function(assert) {
-      let programPromise = program();
-
-      let two = await advanceTo('two');
-      assert.equal(location, 'one-completed');
-
-      two.continue();
-      assert.equal(location, 'two-started');
-
-      let { first, second } = await programPromise;
-      assert.equal(location, 'two-completed');
-      assert.equal(first, 1);
-      assert.equal(second, 2);
-    });
-
-    test('advancing to an already-waiting milestone', async function(assert) {
-      let programPromise = program();
-      assert.equal(location, 'before');
-
-      await advanceTo('one');
-      assert.equal(location, 'before');
-
-      await advanceTo('two').andContinue();
-
-      let { first, second } = await programPromise;
-      assert.equal(first, 1);
-      assert.equal(second, 2);
-    });
-
-    test('advancing to a not-yet-waiting milestone', async function(assert) {
-      let advancePromise = advanceTo('two');
-
-      let programPromise = program();
-      assert.equal(location, 'one-started');
-
-      await advancePromise;
-      assert.equal(location, 'one-completed');
-
-      deactivateAllMilestones();
-      await programPromise;
-    });
-
-    test('advancing while paused at a previous milestone', async function(assert) {
-      let programPromise = program();
-
-      await advanceTo('one');
-      assert.equal(location, 'before');
-
-      let two = await advanceTo('two');
-      assert.equal(location, 'one-completed');
-
-      two.continue();
-
-      assert.deepEqual(await programPromise, { first: 1, second: 2 });
-    });
-
-    test('continuing occurs in a runloop', async function(assert) {
-      let program = async () => {
-        let run = false;
-        await milestone('one', async () => schedule('actions', () => run = true));
-        return run;
-      };
-
-      let programPromise = program();
-      let handle = await advanceTo('one');
-
-      handle.continue();
-      assert.deepEqual(await programPromise, true);
-    });
-
-    test('stubbing a return value', async function(assert) {
-      let programPromise = program();
-
-      await advanceTo('one').andReturn(111);
-      await advanceTo('two').andReturn(222);
-      assert.equal(location, 'two-completed');
-
-      let { first, second } = await programPromise;
-      assert.equal(first, 111);
-      assert.equal(second, 222);
-    });
-
-    test('throwing an exception', async function(assert) {
-      let boom = new Error('boom!');
-      let program = async () => {
-        try {
-          await milestone('one', async () => 'bad');
-        } catch (error) {
-          return error;
-        }
-      };
-
-      advanceTo('one').andThrow(boom);
-      assert.equal(await program(), boom);
-    });
-
-    test('with no callback', async function(assert) {
-      let program = async () => {
-        let first = await milestone('one');
-        let second = await milestone('two');
-        return { first, second };
-      };
-
-      let programPromise = program();
-      await advanceTo('one').andContinue();
-      await advanceTo('two').andContinue();
-      assert.deepEqual(await programPromise, { first: undefined, second: undefined });
-    });
-
-    test('stepping through each location', async function(assert) {
-      let programPromise = program();
-
-      let one = await advanceTo('one');
-      assert.equal(location, 'before');
-
-      one.continue();
-      assert.equal(location, 'one-started');
-
-      let two = await advanceTo('two');
-      assert.equal(location, 'one-completed');
-
-      two.continue();
-      assert.equal(location, 'two-started');
-
-      await programPromise;
-      assert.equal(location, 'two-completed');
-    });
-
-    test('nested milestones', async function(assert) {
-      let program = async () => {
-        location = 'before-out';
-        let result = await milestone('one', async () => {
-          location = 'before-in';
-          let inner = await milestone('two', async () => {
-            location = 'in';
-            return 'ok';
-          });
-          location = 'after-in';
-          return inner;
-        });
-        location = 'after-out';
-        return result;
-      };
-
-      let programPromise = program();
-
-      let one = await advanceTo('one');
-      assert.equal(location, 'before-out');
-
-      let two = await advanceTo('two');
-      assert.equal(location, 'before-in');
-
-      let twoCompletion = two.continue({ immediate: true });
-      assert.equal(location, 'in');
-
-      await twoCompletion;
-      assert.equal(location, 'after-in');
-
-      await one.continue();
-      assert.equal(location, 'after-out');
-
-      assert.equal(await programPromise, 'ok');
-    });
-
-    test('immediate vs deferred continuation', async function(assert) {
-      let program = async () => {
-        location = 'before';
-
-        let result = await milestone('one', async () => 'ok');
-
-        location = 'between';
-
-        await resolve();
-
-        location = 'after';
-
-        return result;
-      };
-
-      let programPromise = program();
-      assert.equal(location, 'before');
-      await advanceTo('one').andContinue({ immediate: true });
-      assert.equal(location, 'between');
-      assert.equal(await programPromise, 'ok');
-
-      programPromise = program();
-      assert.equal(location, 'before');
-      await advanceTo('one').andContinue();
-      assert.equal(location, 'after');
-      assert.equal(await programPromise, 'ok');
-    });
-  });
+  }
 
   module('with multiple milestone sets active', function(hooks) {
-    setupMilestones(hooks, ['one', 'two']);
-    setupMilestones(hooks, ['three', 'four']);
+    let keyOne = Symbol('one');
+    let keyFour = Symbol('four');
+
+    setupMilestones(hooks, [keyOne, 'two']);
+    setupMilestones(hooks, ['three', keyFour]);
 
     test('they can be controlled independently', async function(assert) {
       let state: { [key: string]: any } = {};
-      let program = async (key: string, milestones: string[]) => {
+      let program = async (key: string, milestones: Array<string | symbol>) => {
         state[key] = 'before';
         let first = await milestone(milestones[0], async () => 1);
         state[key] = 'between';
@@ -252,18 +265,18 @@ module('Integration | milestones', function(hooks) {
         return first + second;
       };
 
-      let first = program('first', ['one', 'two']);
-      let second = program('second', ['three', 'four']);
+      let first = program('first', [keyOne, 'two']);
+      let second = program('second', ['three', keyFour]);
 
       assert.equal(state.first, 'before');
       assert.equal(state.second, 'before');
 
-      await advanceTo('one').andReturn(98);
+      await advanceTo(keyOne).andReturn(98);
 
       assert.equal(state.first, 'between');
       assert.equal(state.second, 'before');
 
-      await advanceTo('four').andReturn(9);
+      await advanceTo(keyFour).andReturn(9);
 
       assert.equal(state.first, 'between');
       assert.equal(state.second, 'after');
@@ -278,15 +291,15 @@ module('Integration | milestones', function(hooks) {
     });
 
     test('all active milestones can be deactivated', async function(assert) {
-      let program = async (milestones: string[]) => {
+      let program = async (milestones: Array<string | symbol>) => {
         let first = await milestone(milestones[0], async () => 2);
         let second = await milestone(milestones[1], async () => 3);
         return first * second;
       };
 
-      let first = program(['one', 'two']);
+      let first = program([keyOne, 'two']);
       deactivateAllMilestones();
-      let second = program(['three', 'four']);
+      let second = program(['three', keyFour]);
 
       assert.equal(await first, 6);
       assert.equal(await second, 6);


### PR DESCRIPTION
Per #9, this allows for the use of symbols as milestone keys. In terms of the actual runtime code, there were only a couple of small changes to the implementation:
 - We had a couple uses of `Object.keys` that had to be replaced with something more generic, as that only returns string keys
 - We were interpolating keys directly into strings in places, which will blow up as symbols don't like to be implicitly coerced to strings, so there are now some explicit `.toString()` calls (thanks TypeScript, I would have forgotten about that!)

One note: TS doesn't currently allow symbols in an index type (i.e. `{ [key: symbol]: any }` isn't a thing), so there's a few `as any`s sprinkled in to bypass that. If https://github.com/Microsoft/TypeScript/pull/26797 lands, we ought to be able to clean that up.

@deverstalmage 